### PR TITLE
update dependencies to current versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sbt test
 ## Running the application in local mode
 
 ```
-spark-submit --class com.cloudwick.spark.WordCountRunner \
+spark-submit --class com.careerbuilder.spark.WordCountRunner \
     --master "local[*]" \
     target/scala-2.10/spark-starter_2.10-1.0.jar \
     [input_path] \
@@ -44,7 +44,7 @@ spark-submit --class com.cloudwick.spark.WordCountRunner \
 ## Running the application in the cluster
 
 ```
-spark-submit --class com.cloudwick.spark.WordCountRunner \
+spark-submit --class com.careerbuilder.spark.WordCountRunner \
     --master "local[*]" \
     [path_to_jar]/spark-starter_2.10-1.0.jar \
     [input_path] \

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ resolvers ++= Seq(
   "typesafe-repository" at "http://repo.typesafe.com/typesafe/releases"
 )
 
-val sparkVersion = "1.2.1"
+resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
+
+val sparkVersion = "1.6.0"
 
 // build a uber jar if using any of the external streaming components
 libraryDependencies ++= Seq(
@@ -18,9 +20,11 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-streaming-kafka" % sparkVersion,
   "org.apache.spark" %% "spark-streaming-twitter" % sparkVersion,
   // Test dependencies
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+//  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.scalactic" %% "scalactic" % "3.0.0",
+  "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "org.xerial.snappy" % "snappy-java" % "1.1.1.7"
-)
+ )
 
 parallelExecution in Test := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "spark-starter"
+name := "Carotene4"
 
 version := "1.0"
 
@@ -25,6 +25,13 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "org.xerial.snappy" % "snappy-java" % "1.1.1.7"
  )
+
+assemblyMergeStrategy in assembly := {
+  case PathList("org", "apache", "spark", "unused", "UnusedStubClass.class") => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
 
 parallelExecution in Test := false
 

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
 logLevel := Level.Warn
+resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
+
+addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "1.1.0")

--- a/src/main/scala/com/careerbuilder/spark/WordCount.scala
+++ b/src/main/scala/com/careerbuilder/spark/WordCount.scala
@@ -1,11 +1,11 @@
-package com.cloudwick.spark
+package com.careerbuilder.spark
 
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 
 /**
  * Simple word count application to illustrate spark standalone applications usage
- * @author ashrith
+ * @author oozturk
  */
 
 case class WordCount(word: String, count: Int)

--- a/src/main/scala/com/careerbuilder/spark/WordCountRunner.scala
+++ b/src/main/scala/com/careerbuilder/spark/WordCountRunner.scala
@@ -1,10 +1,10 @@
-package com.cloudwick.spark
+package com.careerbuilder.spark
 
 import org.apache.spark.{SparkContext, SparkConf, Logging}
 
 /**
  * Main method to the Spark WordCount application.
- * @author ashrith
+ * @author oozturk
  */
 object WordCountRunner extends App with Logging {
   if (args.length < 2) {

--- a/src/main/scala/com/careerbuilder/spark/package.scala
+++ b/src/main/scala/com/careerbuilder/spark/package.scala
@@ -1,8 +1,8 @@
-package com.cloudwick
+package com.careerbuilder
 
 /**
  * Pakcage object for examples
- * @author ashrith
+ * @author oozturk
  */
 package object spark {
   implicit class StringUtils(val value: String) {

--- a/src/test/scala/com/careerbuilder/spark/WordCountSpec.scala
+++ b/src/test/scala/com/careerbuilder/spark/WordCountSpec.scala
@@ -1,6 +1,6 @@
-package com.cloudwick.spark
+package com.careerbuilder.spark
 
-import com.cloudwick.spark.sparkspec.SparkSpec
+import com.careerbuilder.spark.WordCount
 import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
 
 /**

--- a/src/test/scala/com/careerbuilder/spark/sparkspec/SparkSpec.scala
+++ b/src/test/scala/com/careerbuilder/spark/sparkspec/SparkSpec.scala
@@ -1,4 +1,4 @@
-package com.cloudwick.spark.sparkspec
+package com.careerbuilder.spark
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{Suite, BeforeAndAfterAll}


### PR DESCRIPTION
Hi,
I am new to sbt.
I tried to update dependencies to current versions.
sbt package succeeds.

In IntelliJ I get this warning (I guess IntelliJ has problem):
SBT project import
            [warn] Scala version was updated by one of library dependencies:
            [warn]  \* org.scala-lang:scala-library:(2.10.5, 2.10.4) -> 2.10.6
            [warn] To force scalaVersion, add the following:
            [warn]  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
            [warn] Run 'evicted' to see detailed eviction warnings
            [warn] Scala version was updated by one of library dependencies:
            [warn]  \* org.scala-lang:scala-library:(2.10.5, 2.10.4) -> 2.10.6
            [warn] To force scalaVersion, add the following:
            [warn]  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
            [warn] Run 'evicted' to see detailed eviction warnings
            [warn] Scala version was updated by one of library dependencies:
            [warn]  \* org.scala-lang:scala-library:(2.10.5, 2.10.4) -> 2.10.6
            [warn] To force scalaVersion, add the following:
            [warn]  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
            [warn] Run 'evicted' to see detailed eviction warnings
...
